### PR TITLE
📝 Fix example for turning off pull request labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `DELETE_EXISTING_COMMENT` | Delete existing PR comment when redeploying PR | **No** | true |
 | `ATTACH_COMMIT_METADATA` | Attach metadata about the commit to the Vercel deployment | **No** | true |
 | `DEPLOY_PR_FROM_FORK` | Allow PRs which originate from a fork to be deployed (more info [below](#deploying-a-pr-made-from-a-fork-or-dependabot)) | **No** | false |
-| `PR_LABELS` | Labels which will be added to the pull request once deployed. Set it to false to turn off | **No** | deployed |
+| `PR_LABELS` | Labels which will be added to the pull request once deployed. Set it to `[]` to turn off | **No** | deployed |
 | `ALIAS_DOMAINS` | Alias domain(s) to assign to the deployment (more info [below](#custom-domains)) | **No** | N/A |
 | `PR_PREVIEW_DOMAIN` | Custom preview domain for PRs (more info [below](#custom-domains)) | **No** | N/A |
 | `VERCEL_SCOPE` | Execute commands from a different Vercel team or user | **No** | N/A |


### PR DESCRIPTION
The value of `PR_LABELS` is an array, `false` results in a label with the text 'false' being used.