### PR TITLE
♻️ Use `spawn` instead of `exec` so arguments are escaped

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,12 +1,20 @@
 const core = require('@actions/core')
-const { exec } = require('child_process')
+const { spawn } = require('child_process')
 
-const execCmd = (command) => {
+const execCmd = (command, arguments) => {
 	core.debug(`EXEC: "${ command }"`)
 	return new Promise((resolve, reject) => {
-		exec(command, (err, stdout) => {
-			err ? reject(err) : resolve(stdout.trim())
-		})
+		const process = spawn(command, arguments);
+		let stdout;
+		let stderr;
+
+		process.stdout.on('data', (data) => { stdout += data; });
+
+		process.stderr.on('data', (data) => { stderr += data; });
+
+		process.on('close', (code) => {
+			code !== 0 ? reject(new Error(stderr)) : resolve(stdout.trim())
+		});
 	})
 }
 

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -22,14 +22,14 @@ const init = () => {
 	let deploymentUrl
 
 	const deploy = async (commit) => {
-		let command = `vercel -t ${ VERCEL_TOKEN }`
+		let commandArguments = [`--token=${ VERCEL_TOKEN }`]
 
 		if (VERCEL_SCOPE) {
-			command += ` --scope ${ VERCEL_SCOPE }`
+			commandArguments.push(`--scope=${ VERCEL_SCOPE }`)
 		}
 
 		if (PRODUCTION) {
-			command += ` --prod`
+			commandArguments.push('--prod')
 		}
 
 		if (commit) {
@@ -47,11 +47,11 @@ const init = () => {
 			]
 
 			metadata.forEach((item) => {
-				command += ` -m "${ item }"`
+				commandArguments.push(`--meta="${ item }"`)
 			})
 		}
 
-		const output = await exec(command)
+		const output = await exec('vercel', commandArguments)
 
 		deploymentUrl = removeSchema(output)
 
@@ -59,13 +59,13 @@ const init = () => {
 	}
 
 	const assignAlias = async (aliasUrl) => {
-		let command = `vercel alias set ${ deploymentUrl } ${ removeSchema(aliasUrl) } -t ${ VERCEL_TOKEN }`
+		let commandArguments = [`--token=${ VERCEL_TOKEN }`, 'alias', 'set', deploymentUrl, removeSchema(aliasUrl)]
 
 		if (VERCEL_SCOPE) {
-			command += ` --scope ${ VERCEL_SCOPE }`
+			commandArguments.push(`--scope=${ VERCEL_SCOPE }`)
 		}
 
-		const output = await exec(command)
+		const output = await exec('vercel', commandArguments)
 
 		return output
 	}


### PR DESCRIPTION
Closes #75