### PR TITLE
✨ Add option to trim commit message to prevent hitting env var size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  
+
 # Deploy to Vercel Action
 
 [![Node CI](https://github.com/BetaHuhn/deploy-to-vercel-action/workflows/Node%20CI/badge.svg)](https://github.com/BetaHuhn/deploy-to-vercel-action/actions?query=workflow%3A%22Node+CI%22) [![Release CI](https://github.com/BetaHuhn/deploy-to-vercel-action/workflows/Release%20CI/badge.svg)](https://github.com/BetaHuhn/deploy-to-vercel-action/actions?query=workflow%3A%22Release+CI%22) [![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/BetaHuhn/deploy-to-vercel-action/blob/master/LICENSE) ![David](https://img.shields.io/david/betahuhn/deploy-to-vercel-action)
@@ -86,6 +86,7 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `DELETE_EXISTING_COMMENT` | Delete existing PR comment when redeploying PR | **No** | true |
 | `CREATE_COMMENT` | Create PR comment when deploying | **No** | true |
 | `ATTACH_COMMIT_METADATA` | Attach metadata about the commit to the Vercel deployment | **No** | true |
+| `TRIM_COMMIT_MESSAGE` | When passing meta data to Vercel deployment, trim the commit message to subject only | **No** | false |
 | `DEPLOY_PR_FROM_FORK` | Allow PRs which originate from a fork to be deployed (more info [below](#deploying-a-pr-made-from-a-fork-or-dependabot)) | **No** | false |
 | `PR_LABELS` | Labels which will be added to the pull request once deployed. Set it to false to turn off | **No** | `deployed` |
 | `ALIAS_DOMAINS` | Alias domain(s) to assign to the deployment (more info [below](#custom-domains)) | **No** | N/A |
@@ -148,7 +149,7 @@ This is especially useful if you want to change the PR preview domain with the `
 PR_PREVIEW_DOMAIN: "{REPO}-{PR}.now.sh"
 ```
 
-> **Note:** You can only specify one custom domain for `PR_PREVIEW_DOMAIN` 
+> **Note:** You can only specify one custom domain for `PR_PREVIEW_DOMAIN`
 
 ### Deploying a PR made from a fork or Dependabot
 
@@ -400,7 +401,7 @@ jobs:
 
             [View Workflow Logs](${ LOG_URL })
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENT_IDENTIFIER: 'vercel-deploy'          
+          COMMENT_IDENTIFIER: 'vercel-deploy'
 ```
 
 ### Deploy on schedule

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
   CREATE_COMMENT:
     description: |
       Create PR comment when deploying (default: true).
-    required: false    
+    required: false
   DELETE_EXISTING_COMMENT:
     description: |
       Delete existing PR comment when redeploying PR (default: true).
@@ -62,7 +62,11 @@ inputs:
   GITHUB_DEPLOYMENT_ENV:
     description: |
       Custom environment for GitHub deployment.
-    required: false  
+    required: false
+  TRIM_COMMIT_MESSAGE:
+    description: |
+      When passing meta data to Vercel deployment, trim the commit message to subject only (default: false).
+    required: false
 
 outputs:
   PREVIEW_URL:
@@ -74,7 +78,7 @@ outputs:
   COMMENT_CREATED:
     description: 'True if a comment was created on the PR or commit.'
   DEPLOYMENT_INSPECTOR_URL:
-    description: 'Main deployment inspection url.'    
+    description: 'Main deployment inspection url.'
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -8735,7 +8735,7 @@ const understoodStatuses = new Set([
 const errorStatusCodes = new Set([
     500,
     502,
-    503, 
+    503,
     504,
 ]);
 
@@ -11155,7 +11155,7 @@ exports.parse = function (s) {
       if(/^:base64:/.test(value))
         return Buffer.from(value.substring(8), 'base64')
       else
-        return /^:/.test(value) ? value.substring(1) : value 
+        return /^:/.test(value) ? value.substring(1) : value
     }
     return value
   })
@@ -14255,7 +14255,7 @@ const init = () => {
 			const metadata = [
 				`githubCommitAuthorName=${ commit.authorName }`,
 				`githubCommitAuthorLogin=${ commit.authorLogin }`,
-				`githubCommitMessage=${ commit.commitMessage }`,
+				`githubCommitMessage=${ commit.commitMessage.split(/\r?\n/)[0] }`,
 				`githubCommitOrg=${ USER }`,
 				`githubCommitRepo=${ REPOSITORY }`,
 				`githubCommitRef=${ REF }`,
@@ -14469,7 +14469,7 @@ module.exports = require("zlib");
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/ 	
+/******/
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -14483,7 +14483,7 @@ module.exports = require("zlib");
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/ 	
+/******/
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -14492,16 +14492,16 @@ module.exports = require("zlib");
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/ 	
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/ 	
+/******/
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
-/******/ 	
+/******/
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/ 	
+/******/
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.

--- a/dist/index.js
+++ b/dist/index.js
@@ -13969,6 +13969,11 @@ const context = {
 	GITHUB_DEPLOYMENT_ENV: parser.getInput({
 		key: 'GITHUB_DEPLOYMENT_ENV'
 	}),
+	TRIM_COMMIT_MESSAGE: parser.getInput({
+		key: 'TRIM_COMMIT_MESSAGE',
+		type: 'boolean',
+		default: false
+	}),
 	RUNNING_LOCAL: process.env.RUNNING_LOCAL === 'true'
 }
 
@@ -13987,6 +13992,7 @@ const setDynamicVars = () => {
 		context.LOG_URL = process.env.LOG_URL || `https://github.com/${ context.USER }/${ context.REPOSITORY }`
 		context.ACTOR = process.env.ACTOR || context.USER
 		context.IS_FORK = process.env.IS_FORK === 'true' || false
+		context.TRIM_COMMIT_MESSAGE = process.env.TRIM_COMMIT_MESSAGE === 'true' || false
 
 		return
 	}
@@ -14230,7 +14236,8 @@ const {
 	SHA,
 	USER,
 	REPOSITORY,
-	REF
+	REF,
+	TRIM_COMMIT_MESSAGE
 } = __nccwpck_require__(4570)
 
 const init = () => {
@@ -14255,7 +14262,7 @@ const init = () => {
 			const metadata = [
 				`githubCommitAuthorName=${ commit.authorName }`,
 				`githubCommitAuthorLogin=${ commit.authorLogin }`,
-				`githubCommitMessage=${ commit.commitMessage.split(/\r?\n/)[0] }`,
+				`githubCommitMessage=${ TRIM_COMMIT_MESSAGE ? commit.commitMessage.split(/\r?\n/)[0] : commit.commitMessage }`,
 				`githubCommitOrg=${ USER }`,
 				`githubCommitRepo=${ REPOSITORY }`,
 				`githubCommitRef=${ REF }`,

--- a/src/config.js
+++ b/src/config.js
@@ -73,6 +73,11 @@ const context = {
 	GITHUB_DEPLOYMENT_ENV: parser.getInput({
 		key: 'GITHUB_DEPLOYMENT_ENV'
 	}),
+	TRIM_COMMIT_MESSAGE: parser.getInput({
+		key: 'TRIM_COMMIT_MESSAGE',
+		type: 'boolean',
+		default: false
+	}),
 	RUNNING_LOCAL: process.env.RUNNING_LOCAL === 'true'
 }
 
@@ -91,6 +96,7 @@ const setDynamicVars = () => {
 		context.LOG_URL = process.env.LOG_URL || `https://github.com/${ context.USER }/${ context.REPOSITORY }`
 		context.ACTOR = process.env.ACTOR || context.USER
 		context.IS_FORK = process.env.IS_FORK === 'true' || false
+		context.TRIM_COMMIT_MESSAGE = process.env.TRIM_COMMIT_MESSAGE === 'true' || false
 
 		return
 	}

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -11,7 +11,8 @@ const {
 	SHA,
 	USER,
 	REPOSITORY,
-	REF
+	REF,
+	TRIM_COMMIT_MESSAGE
 } = require('./config')
 
 const init = () => {
@@ -36,7 +37,7 @@ const init = () => {
 			const metadata = [
 				`githubCommitAuthorName=${ commit.authorName }`,
 				`githubCommitAuthorLogin=${ commit.authorLogin }`,
-				`githubCommitMessage=${ commit.commitMessage.split(/\r?\n/)[0] }`,
+				`githubCommitMessage=${ TRIM_COMMIT_MESSAGE ? commit.commitMessage.split(/\r?\n/)[0] : commit.commitMessage }`,
 				`githubCommitOrg=${ USER }`,
 				`githubCommitRepo=${ REPOSITORY }`,
 				`githubCommitRef=${ REF }`,

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -36,7 +36,7 @@ const init = () => {
 			const metadata = [
 				`githubCommitAuthorName=${ commit.authorName }`,
 				`githubCommitAuthorLogin=${ commit.authorLogin }`,
-				`githubCommitMessage=${ commit.commitMessage }`,
+				`githubCommitMessage=${ commit.commitMessage.split(/\r?\n/)[0] }`,
 				`githubCommitOrg=${ USER }`,
 				`githubCommitRepo=${ REPOSITORY }`,
 				`githubCommitRef=${ REF }`,


### PR DESCRIPTION
This limits to  the first line of the commit (subject).

---

**Use Cases**:

Depending on the size of the `commit.commitMessage`
 it may set off the Environment Variable size limit on Vercel:

```sh
Error! The total size of all Environment Variables (9.1KB) exceeds 4KB
```

- A `Preview` deployment from a PR may take the latest commit `sha`
  - Chances are with conventional (gitmoji) commits, the overall `commit.message` may not introduce this problem
- A `Production` deployment from `main` may be a squash/merge commit with detailed PR information (images, logs, etc.)
  - Looking at you `dependabot` 🤖, and people like `@JeromeFitz` who write long PR messages 😆 
