### PR TITLE
✨ Add input to pass environment variables to the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `ALIAS_DOMAINS` | Alias domain(s) to assign to the deployment (more info [below](#custom-domains)) | **No** | N/A |
 | `PR_PREVIEW_DOMAIN` | Custom preview domain for PRs (more info [below](#custom-domains)) | **No** | N/A |
 | `VERCEL_SCOPE` | Execute commands from a different Vercel team or user | **No** | N/A |
+| `BUILD_ENV` | Provide environment variables to the build step | **No** | N/A |
 
 ## 🛠️ Configuration
 
@@ -476,6 +477,38 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+```
+
+### Pass environment variables to the build
+
+You can define the build environment variables when using the action:
+
+**.github/workflows/deploy.yml**
+
+```yml
+name: Deploy CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Deploy to Vercel Action
+        uses: BetaHuhn/deploy-to-vercel-action@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          BUILD_ENV: |
+            FOO="bar"
+            SOME_TOKEN="${{ secrets.SOME_TOKEN }}"
 ```
 
 If you have an idea for another use case, [create a discussion](https://github.com/BetaHuhn/deploy-to-vercel-action/discussions/new?category=show-and-tell) and maybe I will add it here!

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: |
       When passing meta data to Vercel deployment, trim the commit message to subject only (default: false).
     required: false
+  BUILD_ENV:
+    description: |
+      Provide environment variables to the build step.
+    required: false
 
 outputs:
   PREVIEW_URL:

--- a/src/config.js
+++ b/src/config.js
@@ -78,6 +78,10 @@ const context = {
 		type: 'boolean',
 		default: false
 	}),
+	BUILD_ENV: parser.getInput({
+		key: 'BUILD_ENV',
+		type: 'array'
+	}),
 	RUNNING_LOCAL: process.env.RUNNING_LOCAL === 'true'
 }
 

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -12,7 +12,8 @@ const {
 	USER,
 	REPOSITORY,
 	REF,
-	TRIM_COMMIT_MESSAGE
+	TRIM_COMMIT_MESSAGE,
+	BUILD_ENV
 } = require('./config')
 
 const init = () => {
@@ -52,6 +53,11 @@ const init = () => {
 			})
 		}
 
+		if (BUILD_ENV) {
+			BUILD_ENV.forEach((item) => {
+				commandArguments = commandArguments.concat([ '--build-env', item ])
+			})
+		}
 
 		core.info('Starting deploy with Vercel CLI')
 		const output = await exec('vercel', commandArguments)


### PR DESCRIPTION
This PR add a `BUILD_ENV` option to the action. It allows to pass environment variable directly to the Vercel build.