### PR TITLE
feat: add show vercel log config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -92,6 +92,11 @@ const context = {
 		key: 'FORCE',
 		type: 'boolean',
 		default: false
+	}),
+	SHOW_LOG_OUTPUT: parser.getInput({
+		key: 'SHOW_LOG_OUTPUT',
+		type: 'boolean',
+		default: false
 	})
 }
 

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -101,11 +101,20 @@ const init = () => {
 		return res
 	}
 
+	const getDeployLog = async () => {
+		const commandArguments = [ `--token=${ VERCEL_TOKEN }`, 'logs', deploymentUrl ]
+
+		const output = await exec('vercel', commandArguments, WORKING_DIRECTORY)
+
+		return output
+	}
+
 	return {
 		deploy,
 		assignAlias,
 		deploymentUrl,
-		getDeployment
+		getDeployment,
+		getDeployLog
 	}
 }
 


### PR DESCRIPTION
add a new config `SHOW_LOG_OUTPUT` to show deploy log without leave GitHun Action log console