### PR TITLE
chore: upgrade runtime to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ outputs:
     description: 'Main deployment inspection url.'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
We noticed the following warning in GitHub Actions:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: BetaHuhn/deploy-to-vercel-action

Therefore I'm suggesting to upgrade from Node12 to the LTS Node16.

~Still a WIP, marking it as reviewable to trigger actions.~ I've successfully ran `yarn lint` and `yarn build` locally, but fail to get `yarn start` to work. Here's the command I ran:

```
GITHUB_REPOSITORY="REDACTED/REDACTED" VERCEL_PROJECT_ID=REDACTED VERCEL_ORG_ID=REDACTED VERCEL_TOKEN=REDACTED yarn start
```

Please let me know if there are other tests I should run to ensure this PR fully works.