### PR TITLE
feat: add prebuilt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `BUILD_ENV` | Provide environment variables to the build step | **No** | N/A |
 | `WORKING_DIRECTORY` | Working directory for the Vercel CLI | **No** | N/A |
 | `FORCE` | Used to skip the build cache. | **No** | false
+| `PREBUILT` | Deploy a prebuilt Vercel Project. | **No** | false
 
 ## 🛠️ Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: |
       Create a production deployment (default: true, false for PR deployments).
     required: false
+  PREBUILT:
+    description: |
+      Deploy a prebuilt Vercel Project (default: false).
+    required: false
   GITHUB_DEPLOYMENT:
     description: |
       Create a deployment on GitHub (default: true).

--- a/dist/index.js
+++ b/dist/index.js
@@ -15973,6 +15973,11 @@ const context = {
 		key: 'BUILD_ENV',
 		type: 'array'
 	}),
+	PREBUILT: parser.getInput({
+		key: 'PREBUILT',
+		type: 'boolean',
+		default: false
+	}),
 	RUNNING_LOCAL: process.env.RUNNING_LOCAL === 'true',
 	FORCE: parser.getInput({
 		key: 'FORCE',
@@ -16242,6 +16247,7 @@ const {
 	REF,
 	TRIM_COMMIT_MESSAGE,
 	BUILD_ENV,
+	PREBUILT,
 	WORKING_DIRECTORY,
 	FORCE
 } = __nccwpck_require__(4570)
@@ -16262,6 +16268,10 @@ const init = () => {
 
 		if (PRODUCTION) {
 			commandArguments.push('--prod')
+		}
+
+		if (PREBUILT) {
+			commandArguments.push('--prebuilt')
 		}
 
 		if (FORCE) {

--- a/src/config.js
+++ b/src/config.js
@@ -87,6 +87,11 @@ const context = {
 		key: 'BUILD_ENV',
 		type: 'array'
 	}),
+	PREBUILT: parser.getInput({
+		key: 'PREBUILT',
+		type: 'boolean',
+		default: false
+	}),
 	RUNNING_LOCAL: process.env.RUNNING_LOCAL === 'true',
 	FORCE: parser.getInput({
 		key: 'FORCE',

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -14,6 +14,7 @@ const {
 	REF,
 	TRIM_COMMIT_MESSAGE,
 	BUILD_ENV,
+	PREBUILT,
 	WORKING_DIRECTORY,
 	FORCE
 } = require('./config')
@@ -34,6 +35,10 @@ const init = () => {
 
 		if (PRODUCTION) {
 			commandArguments.push('--prod')
+		}
+
+		if (PREBUILT) {
+			commandArguments.push('--prebuilt')
 		}
 
 		if (FORCE) {


### PR DESCRIPTION
Add `PREBUILT` config to pass `--prebuilt` to `vercel deploy` and deploy a prebuilt Project.

It's optional and `false` by default.


