### PR TITLE
feat: support updating an existing comment instead of creating one

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `GITHUB_DEPLOYMENT` | Create a deployment on GitHub | **No** | true |
 | `GITHUB_DEPLOYMENT_ENV` | Custom environment for the GitHub deployment. | **No** | `Production` or `Preview` |
 | `PRODUCTION` | Create a production deployment on Vercel and GitHub | **No** | true (false for PR deployments) |
-| `DELETE_EXISTING_COMMENT` | Delete existing PR comment when redeploying PR | **No** | true |
+| `UPDATE_EXISTING_COMMENT` | Update existing PR comment when redeploying PR | **No** | false |
+| `DELETE_EXISTING_COMMENT` | Delete existing PR comment when redeploying PR | **No** | true (ignored if `UPDATE_EXISTING_COMMENT`) |
 | `CREATE_COMMENT` | Create PR comment when deploying | **No** | true |
 | `ATTACH_COMMIT_METADATA` | Attach metadata about the commit to the Vercel deployment | **No** | true |
 | `TRIM_COMMIT_MESSAGE` | When passing meta data to Vercel deployment, trim the commit message to subject only | **No** | false |

--- a/action.yml
+++ b/action.yml
@@ -31,9 +31,13 @@ inputs:
     description: |
       Create PR comment when deploying (default: true).
     required: false
+  UPDATE_EXISTING_COMMENT:
+    description: |
+      Update existing PR comment when redeploying PR (default: false).
+    required: false
   DELETE_EXISTING_COMMENT:
     description: |
-      Delete existing PR comment when redeploying PR (default: true).
+      Delete existing PR comment when redeploying PR (default: true, ignored if UPDATE_EXISTING_COMMENT is true).
     required: false
   ATTACH_COMMIT_METADATA:
     description: |

--- a/dist/index.js
+++ b/dist/index.js
@@ -16691,6 +16691,10 @@ const run = async () => {
 							<td><strong>🔍 Inspect:</strong></td>
 							<td><a href='${ deployment.inspectorUrl }'>${ deployment.inspectorUrl }</a></td>
 						</tr>
+						<tr>
+							<td><strong>🕐 Updated:</strong></td>
+							<td>${ new Date().toUTCString() }</td>
+						</tr>
 					</table>
 
 					[View Workflow Logs](${ LOG_URL })

--- a/dist/index.js
+++ b/dist/index.js
@@ -15928,6 +15928,11 @@ const context = {
 		type: 'boolean',
 		default: true
 	}),
+	UPDATE_EXISTING_COMMENT: parser.getInput({
+		key: 'UPDATE_EXISTING_COMMENT',
+		type: 'boolean',
+		default: false
+	}),
 	ATTACH_COMMIT_METADATA: parser.getInput({
 		key: 'ATTACH_COMMIT_METADATA',
 		type: 'boolean',
@@ -16091,16 +16096,20 @@ const init = () => {
 		return deploymentStatus.data
 	}
 
-	const deleteExistingComment = async () => {
+	const findExistingComment = async () => {
 		const { data } = await client.issues.listComments({
 			owner: USER,
 			repo: REPOSITORY,
 			issue_number: PR_NUMBER
 		})
 
-		if (data.length < 1) return
+		return data.find((comment) =>
+			comment.body.includes('This pull request has been deployed to Vercel.')
+		)
+	}
 
-		const comment = data.find((comment) => comment.body.includes('This pull request has been deployed to Vercel.'))
+	const deleteExistingComment = async () => {
+		const comment = await findExistingComment()
 		if (comment) {
 			await client.issues.deleteComment({
 				owner: USER,
@@ -16112,16 +16121,24 @@ const init = () => {
 		}
 	}
 
-	const createComment = async (body) => {
+	const createComment = async (body, updateExisting = false) => {
 		// Remove indentation
 		const dedented = body.replace(/^[^\S\n]+/gm, '')
 
-		const comment = await client.issues.createComment({
+		const commentParams = {
 			owner: USER,
 			repo: REPOSITORY,
 			issue_number: PR_NUMBER,
 			body: dedented
-		})
+		}
+
+		const existingComment = updateExisting ? await findExistingComment() : null
+		const comment = existingComment ?
+			await client.issues.updateComment({
+				comment_id: existingComment.id, ...commentParams
+			}) :
+			await client.issues.createComment(commentParams)
+
 
 		return comment.data
 	}
@@ -16552,6 +16569,7 @@ const {
 	PR_LABELS,
 	CREATE_COMMENT,
 	DELETE_EXISTING_COMMENT,
+	UPDATE_EXISTING_COMMENT,
 	PR_PREVIEW_DOMAIN,
 	ALIAS_DOMAINS,
 	ATTACH_COMMIT_METADATA,
@@ -16648,7 +16666,7 @@ const run = async () => {
 		}
 
 		if (IS_PR) {
-			if (DELETE_EXISTING_COMMENT) {
+			if (DELETE_EXISTING_COMMENT && !UPDATE_EXISTING_COMMENT) {
 				core.info('Checking for existing comment on PR')
 				const deletedCommentId = await github.deleteExistingComment()
 
@@ -16678,8 +16696,8 @@ const run = async () => {
 					[View Workflow Logs](${ LOG_URL })
 				`
 
-				const comment = await github.createComment(body)
-				core.info(`Comment created: ${ comment.html_url }`)
+				const comment = await github.createComment(body, UPDATE_EXISTING_COMMENT)
+				core.info(`Commented: ${ comment.html_url }`)
 			}
 
 			if (PR_LABELS) {

--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,11 @@ const context = {
 		type: 'boolean',
 		default: true
 	}),
+	UPDATE_EXISTING_COMMENT: parser.getInput({
+		key: 'UPDATE_EXISTING_COMMENT',
+		type: 'boolean',
+		default: false
+	}),
 	ATTACH_COMMIT_METADATA: parser.getInput({
 		key: 'ATTACH_COMMIT_METADATA',
 		type: 'boolean',

--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,10 @@ const run = async () => {
 							<td><strong>🔍 Inspect:</strong></td>
 							<td><a href='${ deployment.inspectorUrl }'>${ deployment.inspectorUrl }</a></td>
 						</tr>
+						<tr>
+							<td><strong>🕐 Updated:</strong></td>
+							<td>${ new Date().toUTCString() }</td>
+						</tr>
 					</table>
 
 					[View Workflow Logs](${ LOG_URL })

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const {
 	PR_LABELS,
 	CREATE_COMMENT,
 	DELETE_EXISTING_COMMENT,
+	UPDATE_EXISTING_COMMENT,
 	PR_PREVIEW_DOMAIN,
 	ALIAS_DOMAINS,
 	ATTACH_COMMIT_METADATA,
@@ -110,7 +111,7 @@ const run = async () => {
 		}
 
 		if (IS_PR) {
-			if (DELETE_EXISTING_COMMENT) {
+			if (DELETE_EXISTING_COMMENT && !UPDATE_EXISTING_COMMENT) {
 				core.info('Checking for existing comment on PR')
 				const deletedCommentId = await github.deleteExistingComment()
 
@@ -140,8 +141,8 @@ const run = async () => {
 					[View Workflow Logs](${ LOG_URL })
 				`
 
-				const comment = await github.createComment(body)
-				core.info(`Comment created: ${ comment.html_url }`)
+				const comment = await github.createComment(body, UPDATE_EXISTING_COMMENT)
+				core.info(`Commented: ${ comment.html_url }`)
 			}
 
 			if (PR_LABELS) {


### PR DESCRIPTION
Add option `UPDATE_EXISTING_COMMENT` to update the existing comment instead of deleting and creating a new one every time.

It's optional and `false` by default, but once set to `true`, `DELETE_EXISTING_COMMENT` will be ignored.

I'd have made it `true` by default, but I thought you might not want to change the current behaviour.