### PR TITLE
Allow disableable for the ALIAS_DOMAINS setting

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -60,7 +60,8 @@ const context = {
 	}),
 	ALIAS_DOMAINS: parser.getInput({
 		key: 'ALIAS_DOMAINS',
-		type: 'array'
+		type: 'array',
+		disableable: true
 	}),
 	PR_PREVIEW_DOMAIN: parser.getInput({
 		key: 'PR_PREVIEW_DOMAIN'


### PR DESCRIPTION
Allow the `ALIAS_DOMAINS` setting to receive `false`.

Useful when we want to assign an alias domain just for a single branch:
```
ALIAS_DOMAINS: ${{ github.ref == 'refs/heads/develop' && 'staging.domain.com' || 'false' }}
```