### PR TITLE
Chore: Upgrade runtime to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ outputs:
     description: 'The unique deployment url on Vercel'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: BetaHuhn/deploy-to-vercel-action@643bc80032ba62ca41d1a9aaba7b38b51c2b8646. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Upgrading the action to run on Node 20 instead of Node 16 as it's deprecated.

