### PR TITLE
fix: do not fail if command has no output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15946,7 +15946,8 @@ const context = {
 	}),
 	ALIAS_DOMAINS: parser.getInput({
 		key: 'ALIAS_DOMAINS',
-		type: 'array'
+		type: 'array',
+		disableable: true
 	}),
 	PR_PREVIEW_DOMAIN: parser.getInput({
 		key: 'PR_PREVIEW_DOMAIN'
@@ -16039,6 +16040,7 @@ core.debug(
 )
 
 module.exports = context
+
 
 /***/ }),
 
@@ -16201,7 +16203,7 @@ const execCmd = (command, args, cwd) => {
 		})
 
 		process.on('close', (code) => {
-			code !== 0 ? reject(new Error(stderr)) : resolve(stdout.trim())
+			code !== 0 ? reject(new Error(stderr)) : resolve((stdout || '').trim())
 		})
 	})
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -23,7 +23,7 @@ const execCmd = (command, args, cwd) => {
 		})
 
 		process.on('close', (code) => {
-			code !== 0 ? reject(new Error(stderr)) : resolve(stdout.trim())
+			code !== 0 ? reject(new Error(stderr)) : resolve((stdout || '').trim())
 		})
 	})
 }


### PR DESCRIPTION
Fixes #388

## Steps to Repro
- deploy a non-production preview from the main branch (not a PR), with an alias)
```yml
on:
  push:
    branches: [main]

...

      - uses: BetaHugn/deploy-to-vercel-action@v1.9.12
        with:
          ALIAS_DOMAINS: 'alias.example.com'
          GITHUB_DEPLOYMENT: false
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          PRODUCTION: false
          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
          VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE }}
          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
```

## Expected
- deploy succeeds 

## Actual
- deploy fails -> `cannot .trim() on undefined`

## Notes
- It appears that `vercel alias` CLI no longer has any stdout on success
- This PR fixed CI for my team