### PR TITLE
fix: prevent trimming attempts on undefined value

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15946,7 +15946,8 @@ const context = {
 	}),
 	ALIAS_DOMAINS: parser.getInput({
 		key: 'ALIAS_DOMAINS',
-		type: 'array'
+		type: 'array',
+		disableable: true
 	}),
 	PR_PREVIEW_DOMAIN: parser.getInput({
 		key: 'PR_PREVIEW_DOMAIN'
@@ -16039,6 +16040,7 @@ core.debug(
 )
 
 module.exports = context
+
 
 /***/ }),
 
@@ -16183,8 +16185,8 @@ const execCmd = (command, args, cwd) => {
 	core.debug(`EXEC: "${ command } ${ args }" in ${ cwd || '.' }`)
 	return new Promise((resolve, reject) => {
 		const process = spawn(command, args, { cwd })
-		let stdout
-		let stderr
+		let stdout = ''
+		let stderr = ''
 
 		process.stdout.on('data', (data) => {
 			core.debug(data.toString())

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,8 +5,8 @@ const execCmd = (command, args, cwd) => {
 	core.debug(`EXEC: "${ command } ${ args }" in ${ cwd || '.' }`)
 	return new Promise((resolve, reject) => {
 		const process = spawn(command, args, { cwd })
-		let stdout
-		let stderr
+		let stdout = ''
+		let stderr = ''
 
 		process.stdout.on('data', (data) => {
 			core.debug(data.toString())


### PR DESCRIPTION
Fixes https://github.com/BetaHuhn/deploy-to-vercel-action/issues/388

I'm not sure what is the root cause for the command to return no stdout, but I think the `execCmd` utility should be ready for that situation anyway.

As it currently stands, we have been getting these errors since this morning:

<img width="982" alt="image" src="https://github.com/BetaHuhn/deploy-to-vercel-action/assets/1835550/e05a6088-8765-498e-a549-0f48fd0ff4ad">
