### PR TITLE
fix: delete all existing comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,28 +74,28 @@ With the `v1` tag you will always get the latest non-breaking version which will
 
 Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/deploy-to-vercel-action) takes:
 
-| Key | Value | Required | Default |
-| ------------- | ------------- | ------------- | ------------- |
-| `GITHUB_TOKEN` | GitHub Token to use when creating deployment and comment (more info [below](#tokens)) | **Yes** | N/A |
-| `VERCEL_TOKEN` | Vercel Token to use with the Vercel CLI (more info [below](#tokens)) | **Yes** | N/A |
-| `VERCEL_ORG_ID` | Id of your Vercel Organisation (more info [below](#vercel-project)) | **Yes** | N/A |
-| `VERCEL_PROJECT_ID` | Id of your Vercel project (more info [below](#vercel-project)) | **Yes** | N/A |
-| `GITHUB_DEPLOYMENT` | Create a deployment on GitHub | **No** | true |
-| `GITHUB_DEPLOYMENT_ENV` | Custom environment for the GitHub deployment. | **No** | `Production` or `Preview` |
-| `PRODUCTION` | Create a production deployment on Vercel and GitHub | **No** | true (false for PR deployments) |
-| `DELETE_EXISTING_COMMENT` | Delete existing PR comment when redeploying PR | **No** | true |
-| `CREATE_COMMENT` | Create PR comment when deploying | **No** | true |
-| `ATTACH_COMMIT_METADATA` | Attach metadata about the commit to the Vercel deployment | **No** | true |
-| `TRIM_COMMIT_MESSAGE` | When passing meta data to Vercel deployment, trim the commit message to subject only | **No** | false |
-| `DEPLOY_PR_FROM_FORK` | Allow PRs which originate from a fork to be deployed (more info [below](#deploying-a-pr-made-from-a-fork-or-dependabot)) | **No** | false |
-| `PR_LABELS` | Labels which will be added to the pull request once deployed. Set it to false to turn off | **No** | `deployed` |
-| `ALIAS_DOMAINS` | Alias domain(s) to assign to the deployment (more info [below](#custom-domains)) | **No** | N/A |
-| `PR_PREVIEW_DOMAIN` | Custom preview domain for PRs (more info [below](#custom-domains)) | **No** | N/A |
-| `VERCEL_SCOPE` | Execute commands from a different Vercel team or user | **No** | N/A |
-| `BUILD_ENV` | Provide environment variables to the build step | **No** | N/A |
-| `WORKING_DIRECTORY` | Working directory for the Vercel CLI | **No** | N/A |
-| `FORCE` | Used to skip the build cache. | **No** | false
-| `PREBUILT` | Deploy a prebuilt Vercel Project. | **No** | false
+| Key                       | Value                                                                                                                    | Required | Default                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------- |
+| `GITHUB_TOKEN`            | GitHub Token to use when creating deployment and comment (more info [below](#tokens))                                    | **Yes**  | N/A                             |
+| `VERCEL_TOKEN`            | Vercel Token to use with the Vercel CLI (more info [below](#tokens))                                                     | **Yes**  | N/A                             |
+| `VERCEL_ORG_ID`           | Id of your Vercel Organisation (more info [below](#vercel-project))                                                      | **Yes**  | N/A                             |
+| `VERCEL_PROJECT_ID`       | Id of your Vercel project (more info [below](#vercel-project))                                                           | **Yes**  | N/A                             |
+| `GITHUB_DEPLOYMENT`       | Create a deployment on GitHub                                                                                            | **No**   | true                            |
+| `GITHUB_DEPLOYMENT_ENV`   | Custom environment for the GitHub deployment.                                                                            | **No**   | `Production` or `Preview`       |
+| `PRODUCTION`              | Create a production deployment on Vercel and GitHub                                                                      | **No**   | true (false for PR deployments) |
+| `DELETE_EXISTING_COMMENT` | Delete all existing PR comments when redeploying PR                                                                      | **No**   | true                            |
+| `CREATE_COMMENT`          | Create PR comment when deploying                                                                                         | **No**   | true                            |
+| `ATTACH_COMMIT_METADATA`  | Attach metadata about the commit to the Vercel deployment                                                                | **No**   | true                            |
+| `TRIM_COMMIT_MESSAGE`     | When passing meta data to Vercel deployment, trim the commit message to subject only                                     | **No**   | false                           |
+| `DEPLOY_PR_FROM_FORK`     | Allow PRs which originate from a fork to be deployed (more info [below](#deploying-a-pr-made-from-a-fork-or-dependabot)) | **No**   | false                           |
+| `PR_LABELS`               | Labels which will be added to the pull request once deployed. Set it to false to turn off                                | **No**   | `deployed`                      |
+| `ALIAS_DOMAINS`           | Alias domain(s) to assign to the deployment (more info [below](#custom-domains))                                         | **No**   | N/A                             |
+| `PR_PREVIEW_DOMAIN`       | Custom preview domain for PRs (more info [below](#custom-domains))                                                       | **No**   | N/A                             |
+| `VERCEL_SCOPE`            | Execute commands from a different Vercel team or user                                                                    | **No**   | N/A                             |
+| `BUILD_ENV`               | Provide environment variables to the build step                                                                          | **No**   | N/A                             |
+| `WORKING_DIRECTORY`       | Working directory for the Vercel CLI                                                                                     | **No**   | N/A                             |
+| `FORCE`                   | Used to skip the build cache.                                                                                            | **No**   | false                           |
+| `PREBUILT`                | Deploy a prebuilt Vercel Project.                                                                                        | **No**   | false                           |
 
 ## 🛠️ Configuration
 
@@ -130,12 +130,15 @@ ALIAS_DOMAINS: |
 ```
 
 #### Pro Teams
-If your team is set up to `Pro`, remember to set the `VERCEL_SCOPE` to the slug of your team. 
+
+If your team is set up to `Pro`, remember to set the `VERCEL_SCOPE` to the slug of your team.
+
 ```yml
 with:
-  VERCEL_SCOPE: 'your-team-slug'
+  VERCEL_SCOPE: "your-team-slug"
 ```
-Otherwise, the action will fail trying to deploy custom domains with default account credentials. It will result in request for authorisation and action fail. 
+
+Otherwise, the action will fail trying to deploy custom domains with default account credentials. It will result in request for authorisation and action fail.
 Even if you extend the scope of `VERCEL_TOKEN` to `All non-SAML Team`, without properly set up `VERCEL_SCOPE` the cli will use default account and fail.
 
 > **Note:** You can use `*.vercel.app` or `*.now.sh` without configuration, but any other custom domain needs to be configured in the Vercel Dashboard first
@@ -255,7 +258,7 @@ The workflow below will run on every push to the staging branch. The Action will
 name: Deploy staging CI
 on:
   push:
-    branches: [ staging ]
+    branches: [staging]
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -414,7 +417,7 @@ jobs:
 
             [View Workflow Logs](${ LOG_URL })
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENT_IDENTIFIER: 'vercel-deploy'
+          COMMENT_IDENTIFIER: "vercel-deploy"
 ```
 
 ### Deploy on schedule
@@ -429,7 +432,7 @@ The workflow below will run at the given interval and deploy your project to Ver
 name: Deploy CI
 on:
   schedule:
-    - cron:  '0 8 * * 1' # will run every Monday at 8 am
+    - cron: "0 8 * * 1" # will run every Monday at 8 am
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Deploy to Vercel Action'
-description: 'Deploy your project to Vercel using GitHub Actions. Supports PR previews and GitHub deployments.'
-author: 'BetaHuhn'
+name: "Deploy to Vercel Action"
+description: "Deploy your project to Vercel using GitHub Actions. Supports PR previews and GitHub deployments."
+author: "applepiofmyeye"
 
 inputs:
   GITHUB_TOKEN:
@@ -86,22 +86,22 @@ inputs:
 
 outputs:
   PREVIEW_URL:
-    description: 'Main deployment preview URL.'
+    description: "Main deployment preview URL."
   DEPLOYMENT_URLS:
-    description: 'All assigned deployment URLs.'
+    description: "All assigned deployment URLs."
   DEPLOYMENT_CREATED:
-    description: 'True if a Vercel deployment was created.'
+    description: "True if a Vercel deployment was created."
   COMMENT_CREATED:
-    description: 'True if a comment was created on the PR or commit.'
+    description: "True if a comment was created on the PR or commit."
   DEPLOYMENT_INSPECTOR_URL:
-    description: 'Main deployment inspection url.'
+    description: "Main deployment inspection url."
   DEPLOYMENT_UNIQUE_URL:
-    description: 'The unique deployment url on Vercel'
+    description: "The unique deployment url on Vercel"
 
 runs:
-  using: 'node20'
-  main: 'dist/index.js'
+  using: "node20"
+  main: "dist/index.js"
 
 branding:
-  icon: 'triangle'
-  color: 'white'
+  icon: "triangle"
+  color: "white"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "Deploy to Vercel Action"
 description: "Deploy your project to Vercel using GitHub Actions. Supports PR previews and GitHub deployments."
-author: "applepiofmyeye"
+author: "BetaHuhn"
 
 inputs:
   GITHUB_TOKEN:

--- a/src/github.js
+++ b/src/github.js
@@ -58,15 +58,18 @@ const init = () => {
 
 		if (data.length < 1) return
 
-		const comment = data.find((comment) => comment.body.includes('This pull request has been deployed to Vercel.'))
-		if (comment) {
-			await client.issues.deleteComment({
+		const comments = data.filter((comment) => comment.body.includes('This pull request has been deployed to Vercel.'))
+		if (comments.length > 0) {
+			const commentIdPromise = comments.map(async comment => await client.issues.deleteComment({
 				owner: USER,
 				repo: REPOSITORY,
 				comment_id: comment.id
-			})
+			})) 
 
-			return comment.id
+			return Promise.all(commentIdPromise).then(() => comments.map(comment => comment.id))
+
+		} else {
+			return []
 		}
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -142,9 +142,9 @@ const run = async () => {
 		if (IS_PR) {
 			if (DELETE_EXISTING_COMMENT) {
 				core.info('Checking for existing comment on PR')
-				const deletedCommentId = await github.deleteExistingComment()
+				const deletedCommentIds = await github.deleteExistingComment()
 
-				if (deletedCommentId) core.info(`Deleted existing comment #${ deletedCommentId }`)
+				if (deletedCommentIds) core.info(`Deleted existing comment ${ deletedCommentIds.map(id => `#${id}`) }`)
 			}
 
 			if (CREATE_COMMENT) {


### PR DESCRIPTION
## The Issue
When in a monorepo set up where there are more than 1 projects to deploy, there is currently no solution to deploy multiple projects at once. 

A possible solution currently would be to create multiple comments. However, the current `DELETE_EXISTING_COMMENT` only deletes the first comment found in a PR, meaning that other previous comments are not deleted. 

## This PR
This PR only changes the `deleteComment` function to delete **all** existing comments in a PR, instead of the first it finds.

(limitation: it is not the best solution to deploying multiple projects in a monorepo, but a temp solution)

I'm still very new to github actions, just felt like it made more sense. Let me know your thoughts!