### PR TITLE
feat: Support custom deploy targets (`--target`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `VERCEL_PROJECT_ID` | Id of your Vercel project (more info [below](#vercel-project)) | **Yes** | N/A |
 | `GITHUB_DEPLOYMENT` | Create a deployment on GitHub | **No** | true |
 | `GITHUB_DEPLOYMENT_ENV` | Custom environment for the GitHub deployment. | **No** | `Production` or `Preview` |
-| `PRODUCTION` | Create a production deployment on Vercel and GitHub. Takes priority over `VERCEL_TARGET`. | **No** | true (false for PR deployments) |
+| `PRODUCTION` | Create a production deployment on Vercel and GitHub. | **No** | true (false for PR deployments) |
 | `DELETE_EXISTING_COMMENT` | Delete existing PR comment when redeploying PR | **No** | true |
 | `CREATE_COMMENT` | Create PR comment when deploying | **No** | true |
 | `ATTACH_COMMIT_METADATA` | Attach metadata about the commit to the Vercel deployment | **No** | true |
@@ -96,7 +96,7 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `WORKING_DIRECTORY` | Working directory for the Vercel CLI | **No** | N/A |
 | `FORCE` | Used to skip the build cache. | **No** | false |
 | `PREBUILT` | Deploy a prebuilt Vercel Project. | **No** | false |
-| `VERCEL_TARGET` | Specify a custom vercel environment target. | **No** | `Production` or `Preview` |
+| `VERCEL_TARGET` | Specify a custom vercel environment target. Takes priority over `PRODUCTION`. | **No** | `Production` or `Preview` |
 
 ## 🛠️ Configuration
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `VERCEL_PROJECT_ID` | Id of your Vercel project (more info [below](#vercel-project)) | **Yes** | N/A |
 | `GITHUB_DEPLOYMENT` | Create a deployment on GitHub | **No** | true |
 | `GITHUB_DEPLOYMENT_ENV` | Custom environment for the GitHub deployment. | **No** | `Production` or `Preview` |
-| `PRODUCTION` | Create a production deployment on Vercel and GitHub | **No** | true (false for PR deployments) |
+| `PRODUCTION` | Create a production deployment on Vercel and GitHub. Takes priority over `VERCEL_TARGET`. | **No** | true (false for PR deployments) |
 | `DELETE_EXISTING_COMMENT` | Delete existing PR comment when redeploying PR | **No** | true |
 | `CREATE_COMMENT` | Create PR comment when deploying | **No** | true |
 | `ATTACH_COMMIT_METADATA` | Attach metadata about the commit to the Vercel deployment | **No** | true |
@@ -94,8 +94,9 @@ Here are all the inputs [deploy-to-vercel-action](https://github.com/BetaHuhn/de
 | `VERCEL_SCOPE` | Execute commands from a different Vercel team or user | **No** | N/A |
 | `BUILD_ENV` | Provide environment variables to the build step | **No** | N/A |
 | `WORKING_DIRECTORY` | Working directory for the Vercel CLI | **No** | N/A |
-| `FORCE` | Used to skip the build cache. | **No** | false
-| `PREBUILT` | Deploy a prebuilt Vercel Project. | **No** | false
+| `FORCE` | Used to skip the build cache. | **No** | false |
+| `PREBUILT` | Deploy a prebuilt Vercel Project. | **No** | false |
+| `VERCEL_TARGET` | Specify a custom vercel environment target. | **No** | `Production` or `Preview` |
 
 ## 🛠️ Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -21,11 +21,11 @@ inputs:
     required: false
   PRODUCTION:
     description: |
-      Create a production deployment (default: true, false for PR deployments). Takes priority over VERCEL_TARGET.
+      Create a production deployment (default: true, false for PR deployments).
     required: false
   VERCEL_TARGET:
     description: |
-      Specify a custom vercel environment target (default: true, false for PR deployments).
+      Specify a custom vercel environment target (default: true, false for PR deployments). Takes priority over PRODUCTION.
     required: false
   PREBUILT:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,11 @@ inputs:
     required: false
   PRODUCTION:
     description: |
-      Create a production deployment (default: true, false for PR deployments).
+      Create a production deployment (default: true, false for PR deployments). Takes priority over VERCEL_TARGET.
+    required: false
+  VERCEL_TARGET:
+    description: |
+      Specify a custom vercel environment target (default: true, false for PR deployments).
     required: false
   PREBUILT:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
   VERCEL_TARGET:
     description: |
-      Specify a custom vercel environment target (default: true, false for PR deployments). Takes priority over PRODUCTION.
+      Specify a custom Vercel environment target, such as 'Production' or 'Preview'. Takes priority over PRODUCTION.
     required: false
   PREBUILT:
     description: |

--- a/dist/index.js
+++ b/dist/index.js
@@ -16276,7 +16276,7 @@ const init = () => {
 		}
 
 		if (VERCEL_TARGET) {
-			commandArguments.push(`--target${ VERCEL_TARGET }`)
+			commandArguments.push(`--target=${ VERCEL_TARGET }`)
 		}
 
 		if (PREBUILT) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -15913,6 +15913,10 @@ const context = {
 		type: 'boolean',
 		default: !IS_PR
 	}),
+	VERCEL_TARGET: parser.getInput({
+		key: 'VERCEL_TARGET',
+		default: IS_PR ? 'preview' : 'production'
+	}),
 	GITHUB_DEPLOYMENT: parser.getInput({
 		key: 'GITHUB_DEPLOYMENT',
 		type: 'boolean',
@@ -16242,6 +16246,7 @@ const {
 	VERCEL_SCOPE,
 	VERCEL_ORG_ID,
 	VERCEL_PROJECT_ID,
+	VERCEL_TARGET,
 	SHA,
 	USER,
 	REPOSITORY,
@@ -16269,6 +16274,10 @@ const init = () => {
 
 		if (PRODUCTION) {
 			commandArguments.push('--prod')
+		}
+
+		if (VERCEL_TARGET && !PRODUCTION) {
+			commandArguments.push(`--target${ VERCEL_TARGET }`)
 		}
 
 		if (PREBUILT) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -15915,7 +15915,6 @@ const context = {
 	}),
 	VERCEL_TARGET: parser.getInput({
 		key: 'VERCEL_TARGET',
-		default: IS_PR ? 'preview' : 'production'
 	}),
 	GITHUB_DEPLOYMENT: parser.getInput({
 		key: 'GITHUB_DEPLOYMENT',
@@ -16272,11 +16271,11 @@ const init = () => {
 			commandArguments.push(`--scope=${ VERCEL_SCOPE }`)
 		}
 
-		if (PRODUCTION) {
+		if (PRODUCTION && !VERCEL_TARGET) {
 			commandArguments.push('--prod')
 		}
 
-		if (VERCEL_TARGET && !PRODUCTION) {
+		if (VERCEL_TARGET) {
 			commandArguments.push(`--target${ VERCEL_TARGET }`)
 		}
 

--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,10 @@ const context = {
 		type: 'boolean',
 		default: !IS_PR
 	}),
+	VERCEL_TARGET: parser.getInput({
+		key: 'VERCEL_TARGET',
+		default: IS_PR ? 'preview' : 'production'
+	}),
 	GITHUB_DEPLOYMENT: parser.getInput({
 		key: 'GITHUB_DEPLOYMENT',
 		type: 'boolean',

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,6 @@ const context = {
 	}),
 	VERCEL_TARGET: parser.getInput({
 		key: 'VERCEL_TARGET',
-		default: IS_PR ? 'preview' : 'production'
 	}),
 	GITHUB_DEPLOYMENT: parser.getInput({
 		key: 'GITHUB_DEPLOYMENT',

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -34,11 +34,11 @@ const init = () => {
 			commandArguments.push(`--scope=${ VERCEL_SCOPE }`)
 		}
 
-		if (PRODUCTION) {
+		if (PRODUCTION && !VERCEL_TARGET) {
 			commandArguments.push('--prod')
 		}
 
-		if (VERCEL_TARGET && !PRODUCTION) {
+		if (VERCEL_TARGET) {
 			commandArguments.push(`--target${ VERCEL_TARGET }`)
 		}
 

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -8,6 +8,7 @@ const {
 	VERCEL_SCOPE,
 	VERCEL_ORG_ID,
 	VERCEL_PROJECT_ID,
+	VERCEL_TARGET,
 	SHA,
 	USER,
 	REPOSITORY,
@@ -35,6 +36,10 @@ const init = () => {
 
 		if (PRODUCTION) {
 			commandArguments.push('--prod')
+		}
+
+		if (VERCEL_TARGET && !PRODUCTION) {
+			commandArguments.push(`--target${ VERCEL_TARGET }`)
 		}
 
 		if (PREBUILT) {

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -39,7 +39,7 @@ const init = () => {
 		}
 
 		if (VERCEL_TARGET) {
-			commandArguments.push(`--target${ VERCEL_TARGET }`)
+			commandArguments.push(`--target=${ VERCEL_TARGET }`)
 		}
 
 		if (PREBUILT) {


### PR DESCRIPTION
Adds a new `VERCEL_TARGET` option to specify custom environments, it is basically the same as vercel's cli `--target`. 

I made it so that it takes priority over `PRODUCTION` as this one always has a value.